### PR TITLE
Update background.js, add Auto login for UCP Web client

### DIFF
--- a/background.js
+++ b/background.js
@@ -166,6 +166,10 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
       else if (urlPartAfterIp.startsWith('umc') && (tabs[0].title === 'User Management Control' || tabs[0].title === 'User Management Component')) {
         appType = -1; //UMC
       }
+      //added, AutoLogin WebClient UCP
+      else if (urlPartAfterIp.startsWith('device') && tabs[0].title === 'WinCC Unified RT')   {
+         appType = 1; //UCP Web client
+      }
       console.log(urlPartAfterIp);
       console.log(tabs[0].title);
       if (appType > 0) {


### PR DESCRIPTION
I added code for using auto login also for using with Unified Comfort Panel Web client.
It works in my tests (with UCP Image V19 Upd. 2) with Chrome running in Windows and Linux. 
I put the app type=1, same as runtime. I am not sure if it is the best way to do that.